### PR TITLE
add thinking content token

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -79,6 +79,7 @@ class UsageMetadataChunk(BaseModel):
   prompt_tokens: int
   completion_tokens: int
   total_tokens: int
+  thoughts_token_count: int
 
 
 class LiteLLMClient:
@@ -420,6 +421,7 @@ def _model_response_to_chunk(
         prompt_tokens=response["usage"].get("prompt_tokens", 0),
         completion_tokens=response["usage"].get("completion_tokens", 0),
         total_tokens=response["usage"].get("total_tokens", 0),
+        thoughts_token_count=getattr(response["usage"]["completion_tokens_details"], "reasoning_tokens", 0),
     ), None
 
 
@@ -448,6 +450,7 @@ def _model_response_to_generate_content_response(
         prompt_token_count=response["usage"].get("prompt_tokens", 0),
         candidates_token_count=response["usage"].get("completion_tokens", 0),
         total_token_count=response["usage"].get("total_tokens", 0),
+        thoughts_token_count=getattr(response["usage"]["completion_tokens_details"], "reasoning_tokens", 0),
     )
   return llm_response
 
@@ -766,6 +769,7 @@ class LiteLlm(BaseLlm):
                 prompt_token_count=chunk.prompt_tokens,
                 candidates_token_count=chunk.completion_tokens,
                 total_token_count=chunk.total_tokens,
+                thoughts_token_count=chunk.completion_tokens_details.reasoning_tokens,
             )
 
           if (


### PR DESCRIPTION
在`textbook_writer/problem_curator/main.py`中，在`run_prompt`函数中`async for event in runner.run_async`内：
`event.usage_metadata.prompt_token_count`是传给大模型的prompt的token数
`event.usage_metadata.candidates_token_count`是收到大模型回复的正式内容的token数
`event.usage_metadata.total_token_count`对应总token数，等于`prompt_token_count+candidates_token_count`
本次改动增加了思维链的token数的输出，可通过`event.usage_metadata.thoughts_token_count`来获取